### PR TITLE
add game filters to provide second game functionality and selectbox f…

### DIFF
--- a/document_indexing/populate_document_store.py
+++ b/document_indexing/populate_document_store.py
@@ -32,14 +32,15 @@ def question_answer_pair_to_document_store_format(q_and_a_pair: QuestionAnswerPa
     }
 
 
-def populate_document_store(game: str,delete_docs=True):
+def populate_document_store(game: str, delete_docs=True):
 
     s3_storage = S3Storage()
 
     # Extraction part
     rulebook_file_path = s3_storage.load_rulebook_path(game)
     extractive_document_store = ElasticsearchDocumentStore(index="rulebook", embedding_dim=768)
-    if delete_docs: extractive_document_store.delete_documents(index="rulebook")
+    if delete_docs:
+        extractive_document_store.delete_documents(index="rulebook")
     converter = PDFToTextConverter(remove_numeric_tables=True, valid_languages=["en"])
     doc_pdf = converter.convert(file_path=rulebook_file_path, meta={"game": game})[0]
 
@@ -59,7 +60,8 @@ def populate_document_store(game: str,delete_docs=True):
     q_and_a_pairs = [question_answer_pair_to_document_store_format(qap) for qap in q_and_a_pairs]
     logger.info(f"Loading {len(q_and_a_pairs)} Q and A pairs")
     faq_document_store = ElasticsearchDocumentStore(index="faq", embedding_dim=384, similarity="cosine")
-    if delete_docs: faq_document_store.delete_documents(index="faq")
+    if delete_docs:
+        faq_document_store.delete_documents(index="faq")
     faq_document_store.write_documents(q_and_a_pairs, index="faq")
 
 
@@ -73,5 +75,5 @@ def check_es():
 
 if __name__ == "__main__":
     populate_document_store("monopoly")
-    populate_document_store("gloomhaven",delete_docs=False)
+    populate_document_store("gloomhaven", delete_docs=False)
     check_es()

--- a/ui/webapp.py
+++ b/ui/webapp.py
@@ -170,6 +170,7 @@ def ui_page():
             try:
                 st.session_state.results, st.session_state.raw_json = query(
                     question,
+                    filters={"game": selected_game},
                     index_option=st.session_state.index_option_query,
                     top_k_reader_rulebook=top_k_reader_rulebook,
                     top_k_reader_faq=top_k_reader_faq,
@@ -317,6 +318,13 @@ if __name__ == "__main__":
     if option_name == "User interface":
         # Sidebar
         st.sidebar.header("Options")
+
+        selected_game = st.sidebar.selectbox(
+        "Choose Game",
+        ("monopoly", "gloomhaven"),
+        index=0
+        )
+
         top_k_reader_rulebook = st.sidebar.slider(
             "Max. number of answers from rulebook",
             min_value=1,

--- a/ui/webapp.py
+++ b/ui/webapp.py
@@ -1,7 +1,4 @@
-import os
-import sys
 import logging
-from pathlib import Path
 from json import JSONDecodeError
 
 import pandas as pd
@@ -319,11 +316,7 @@ if __name__ == "__main__":
         # Sidebar
         st.sidebar.header("Options")
 
-        selected_game = st.sidebar.selectbox(
-        "Choose Game",
-        ("monopoly", "gloomhaven"),
-        index=0
-        )
+        selected_game = st.sidebar.selectbox("Choose Game", ("monopoly", "gloomhaven"), index=0)
 
         top_k_reader_rulebook = st.sidebar.slider(
             "Max. number of answers from rulebook",


### PR DESCRIPTION
### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Added functionality to search through FAQ and Rulebook for the additional game Gloomhaven through the existing Streamlit user interface. A selectbox was added so users can toggle between Monopoly and Gloomhaven games.


### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Built fresh docker images with new features and deployed onto a new machine for testing. tested queries for both games through FAQ and Rulebook pipelines.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
the results are fairly mixed, the rulebook pipeline in particular seems to struggle to give good answers, my intuition is that the passage lengths are a bit too short for the more complex questions and answers that such a game will need. Also preprocessing of the Haystack rulebook could definitely be improved as some responses contain sections of non-text characters.
